### PR TITLE
SQA Infrastructure for TMAP8

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -8,6 +8,9 @@ Extensions:
         name: TMAP8
         repo: https://github.com/idaholab/TMAP8
         menu:
+            Documentation:
+              TMAP8-only Syntax: syntax/tmap_only.md
+              Complete Code Syntax: syntax/index.md
             Software Quality: sqa/index.md
     MooseDocs.extensions.appsyntax:
         executable: ${ROOT_DIR}

--- a/doc/config.yml
+++ b/doc/config.yml
@@ -8,13 +8,19 @@ Content:
             - css/*
             - contrib/**
             - media/**
-
 Renderer:
     type: MooseDocs.base.MaterializeRenderer
     name: TMAP
-
 Extensions:
     MooseDocs.extensions.appsyntax:
         executable: ${ROOT_DIR}
         includes:
             - include
+    MooseDocs.extensions.sqa:
+        active: true
+        categories:
+            framework: !include ${MOOSE_DIR}/framework/doc/sqa_framework.yml
+            tmap: !include ${ROOT_DIR}/doc/sqa_tmap.yml
+        reports: !include ${ROOT_DIR}/doc/sqa_reports.yml
+    MooseDocs.extensions.template:
+        active: true

--- a/doc/config.yml
+++ b/doc/config.yml
@@ -1,26 +1,31 @@
 Content:
-    TMAP:
-        root_dir: ${ROOT_DIR}/doc/content
-    moose:
-        root_dir: ${MOOSE_DIR}/framework/doc/content
-        content:
-            - js/*
-            - css/*
-            - contrib/**
-            - media/**
+    - ${ROOT_DIR}/doc/content
+    - ${MOOSE_DIR}/framework/doc/content
 Renderer:
     type: MooseDocs.base.MaterializeRenderer
-    name: TMAP
 Extensions:
+    MooseDocs.extensions.navigation:
+        name: TMAP8
+        repo: https://github.com/idaholab/TMAP8
+        menu:
+            Software Quality: sqa/index.md
     MooseDocs.extensions.appsyntax:
         executable: ${ROOT_DIR}
         includes:
             - include
+        remove:
+            framework: !include ${MOOSE_DIR}/framework/doc/remove.yml
+    MooseDocs.extensions.common:
+        shortcuts: !include ${MOOSE_DIR}/framework/doc/globals.yml
+    MooseDocs.extensions.acronym:
+        acronyms: !include ${MOOSE_DIR}/framework/doc/acronyms.yml
     MooseDocs.extensions.sqa:
         active: true
         categories:
             framework: !include ${MOOSE_DIR}/framework/doc/sqa_framework.yml
             tmap: !include ${ROOT_DIR}/doc/sqa_tmap.yml
+        repos:
+            default: https://github.com/idaholab/TMAP8
         reports: !include ${ROOT_DIR}/doc/sqa_reports.yml
     MooseDocs.extensions.template:
         active: true

--- a/doc/content/source/bcs/BinaryRecombinationBC.md
+++ b/doc/content/source/bcs/BinaryRecombinationBC.md
@@ -1,0 +1,23 @@
+# BinaryRecombinationBC
+
+!alert construction title=Undocumented Class
+The BinaryRecombinationBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/BinaryRecombinationBC
+
+## Overview
+
+!! Replace these lines with information regarding the BinaryRecombinationBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the BinaryRecombinationBC object.
+
+!syntax parameters /BCs/BinaryRecombinationBC
+
+!syntax inputs /BCs/BinaryRecombinationBC
+
+!syntax children /BCs/BinaryRecombinationBC

--- a/doc/content/source/bcs/DissociationFluxBC.md
+++ b/doc/content/source/bcs/DissociationFluxBC.md
@@ -1,0 +1,23 @@
+# DissociationFluxBC
+
+!alert construction title=Undocumented Class
+The DissociationFluxBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/DissociationFluxBC
+
+## Overview
+
+!! Replace these lines with information regarding the DissociationFluxBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DissociationFluxBC object.
+
+!syntax parameters /BCs/DissociationFluxBC
+
+!syntax inputs /BCs/DissociationFluxBC
+
+!syntax children /BCs/DissociationFluxBC

--- a/doc/content/source/bcs/EquilibriumBC.md
+++ b/doc/content/source/bcs/EquilibriumBC.md
@@ -1,0 +1,23 @@
+# EquilibriumBC
+
+!alert construction title=Undocumented Class
+The EquilibriumBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/EquilibriumBC
+
+## Overview
+
+!! Replace these lines with information regarding the EquilibriumBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EquilibriumBC object.
+
+!syntax parameters /BCs/EquilibriumBC
+
+!syntax inputs /BCs/EquilibriumBC
+
+!syntax children /BCs/EquilibriumBC

--- a/doc/content/source/bcs/UnaryRecombinationBC.md
+++ b/doc/content/source/bcs/UnaryRecombinationBC.md
@@ -1,0 +1,23 @@
+# UnaryRecombinationBC
+
+!alert construction title=Undocumented Class
+The UnaryRecombinationBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/UnaryRecombinationBC
+
+## Overview
+
+!! Replace these lines with information regarding the UnaryRecombinationBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the UnaryRecombinationBC object.
+
+!syntax parameters /BCs/UnaryRecombinationBC
+
+!syntax inputs /BCs/UnaryRecombinationBC
+
+!syntax children /BCs/UnaryRecombinationBC

--- a/doc/content/source/kernels/BodyForceLM.md
+++ b/doc/content/source/kernels/BodyForceLM.md
@@ -1,0 +1,23 @@
+# BodyForceLM
+
+!alert construction title=Undocumented Class
+The BodyForceLM has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/BodyForceLM
+
+## Overview
+
+!! Replace these lines with information regarding the BodyForceLM object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the BodyForceLM object.
+
+!syntax parameters /Kernels/BodyForceLM
+
+!syntax inputs /Kernels/BodyForceLM
+
+!syntax children /Kernels/BodyForceLM

--- a/doc/content/source/kernels/CoupledForceLM.md
+++ b/doc/content/source/kernels/CoupledForceLM.md
@@ -1,0 +1,23 @@
+# CoupledForceLM
+
+!alert construction title=Undocumented Class
+The CoupledForceLM has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/CoupledForceLM
+
+## Overview
+
+!! Replace these lines with information regarding the CoupledForceLM object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the CoupledForceLM object.
+
+!syntax parameters /Kernels/CoupledForceLM
+
+!syntax inputs /Kernels/CoupledForceLM
+
+!syntax children /Kernels/CoupledForceLM

--- a/doc/content/source/kernels/LMDiffusion.md
+++ b/doc/content/source/kernels/LMDiffusion.md
@@ -1,0 +1,23 @@
+# LMDiffusion
+
+!alert construction title=Undocumented Class
+The LMDiffusion has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/LMDiffusion
+
+## Overview
+
+!! Replace these lines with information regarding the LMDiffusion object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the LMDiffusion object.
+
+!syntax parameters /Kernels/LMDiffusion
+
+!syntax inputs /Kernels/LMDiffusion
+
+!syntax children /Kernels/LMDiffusion

--- a/doc/content/source/kernels/RequirePositiveNCP.md
+++ b/doc/content/source/kernels/RequirePositiveNCP.md
@@ -1,0 +1,23 @@
+# RequirePositiveNCP
+
+!alert construction title=Undocumented Class
+The RequirePositiveNCP has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/RequirePositiveNCP
+
+## Overview
+
+!! Replace these lines with information regarding the RequirePositiveNCP object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the RequirePositiveNCP object.
+
+!syntax parameters /Kernels/RequirePositiveNCP
+
+!syntax inputs /Kernels/RequirePositiveNCP
+
+!syntax children /Kernels/RequirePositiveNCP

--- a/doc/content/source/kernels/ScaledCoupledTimeDerivative.md
+++ b/doc/content/source/kernels/ScaledCoupledTimeDerivative.md
@@ -1,0 +1,23 @@
+# ScaledCoupledTimeDerivative
+
+!alert construction title=Undocumented Class
+The ScaledCoupledTimeDerivative has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ScaledCoupledTimeDerivative
+
+## Overview
+
+!! Replace these lines with information regarding the ScaledCoupledTimeDerivative object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ScaledCoupledTimeDerivative object.
+
+!syntax parameters /Kernels/ScaledCoupledTimeDerivative
+
+!syntax inputs /Kernels/ScaledCoupledTimeDerivative
+
+!syntax children /Kernels/ScaledCoupledTimeDerivative

--- a/doc/content/source/kernels/TimeDerivativeLM.md
+++ b/doc/content/source/kernels/TimeDerivativeLM.md
@@ -1,0 +1,23 @@
+# TimeDerivativeLM
+
+!alert construction title=Undocumented Class
+The TimeDerivativeLM has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/TimeDerivativeLM
+
+## Overview
+
+!! Replace these lines with information regarding the TimeDerivativeLM object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the TimeDerivativeLM object.
+
+!syntax parameters /Kernels/TimeDerivativeLM
+
+!syntax inputs /Kernels/TimeDerivativeLM
+
+!syntax children /Kernels/TimeDerivativeLM

--- a/doc/content/source/nodal_kernels/ReleasingNodalKernel.md
+++ b/doc/content/source/nodal_kernels/ReleasingNodalKernel.md
@@ -1,0 +1,23 @@
+# ReleasingNodalKernel
+
+!alert construction title=Undocumented Class
+The ReleasingNodalKernel has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /NodalKernels/ReleasingNodalKernel
+
+## Overview
+
+!! Replace these lines with information regarding the ReleasingNodalKernel object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ReleasingNodalKernel object.
+
+!syntax parameters /NodalKernels/ReleasingNodalKernel
+
+!syntax inputs /NodalKernels/ReleasingNodalKernel
+
+!syntax children /NodalKernels/ReleasingNodalKernel

--- a/doc/content/source/nodal_kernels/TrappingNodalKernel.md
+++ b/doc/content/source/nodal_kernels/TrappingNodalKernel.md
@@ -1,0 +1,23 @@
+# TrappingNodalKernel
+
+!alert construction title=Undocumented Class
+The TrappingNodalKernel has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /NodalKernels/TrappingNodalKernel
+
+## Overview
+
+!! Replace these lines with information regarding the TrappingNodalKernel object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the TrappingNodalKernel object.
+
+!syntax parameters /NodalKernels/TrappingNodalKernel
+
+!syntax inputs /NodalKernels/TrappingNodalKernel
+
+!syntax children /NodalKernels/TrappingNodalKernel

--- a/doc/content/source/postprocessors/PressureReleaseFluxIntegral.md
+++ b/doc/content/source/postprocessors/PressureReleaseFluxIntegral.md
@@ -1,0 +1,23 @@
+# PressureReleaseFluxIntegral
+
+!alert construction title=Undocumented Class
+The PressureReleaseFluxIntegral has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /UserObjects/PressureReleaseFluxIntegral
+
+## Overview
+
+!! Replace these lines with information regarding the PressureReleaseFluxIntegral object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the PressureReleaseFluxIntegral object.
+
+!syntax parameters /UserObjects/PressureReleaseFluxIntegral
+
+!syntax inputs /UserObjects/PressureReleaseFluxIntegral
+
+!syntax children /UserObjects/PressureReleaseFluxIntegral

--- a/doc/content/source/scalar_kernels/EnclosureSinkScalarKernel.md
+++ b/doc/content/source/scalar_kernels/EnclosureSinkScalarKernel.md
@@ -1,0 +1,23 @@
+# EnclosureSinkScalarKernel
+
+!alert construction title=Undocumented Class
+The EnclosureSinkScalarKernel has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /ScalarKernels/EnclosureSinkScalarKernel
+
+## Overview
+
+!! Replace these lines with information regarding the EnclosureSinkScalarKernel object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the EnclosureSinkScalarKernel object.
+
+!syntax parameters /ScalarKernels/EnclosureSinkScalarKernel
+
+!syntax inputs /ScalarKernels/EnclosureSinkScalarKernel
+
+!syntax children /ScalarKernels/EnclosureSinkScalarKernel

--- a/doc/content/sqa/index.md
+++ b/doc/content/sqa/index.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_index.md.template app=TMAPApp category=tmap

--- a/doc/content/sqa/tmap_far.md
+++ b/doc/content/sqa/tmap_far.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_far.md.template app=TMAPApp category=tmap

--- a/doc/content/sqa/tmap_rtm.md
+++ b/doc/content/sqa/tmap_rtm.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_rtm.md.template app=TMAPApp category=tmap

--- a/doc/content/sqa/tmap_sdd.md
+++ b/doc/content/sqa/tmap_sdd.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_sdd.md.template app=TMAPApp category=tmap

--- a/doc/content/sqa/tmap_srs.md
+++ b/doc/content/sqa/tmap_srs.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_srs.md.template app=TMAPApp category=tmap

--- a/doc/content/sqa/tmap_stp.md
+++ b/doc/content/sqa/tmap_stp.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_stp.md.template app=TMAPApp category=tmap

--- a/doc/content/sqa/tmap_vvr.md
+++ b/doc/content/sqa/tmap_vvr.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_vvr.md.template app=TMAPApp category=tmap

--- a/doc/content/syntax/index.md
+++ b/doc/content/syntax/index.md
@@ -1,0 +1,14 @@
+# Complete TMAP8 Input File Syntax
+
+Listed below are all the reference pages for both TMAP8 specific code and the
+MOOSE code that can be used in the TMAP8 input file.
+
+Click the blue links in the class names shown below to view the detailed
+description, the class purpose, theoretical models, input file examples, and
+references.
+
+Click the blue icon link shown to the right of each main class type heading
+(e.g. Adaptivity) to see a more detailed description of the class type purpose
+within TMAP8 and the MOOSE framework.
+
+!syntax complete

--- a/doc/content/syntax/tmap_only.md
+++ b/doc/content/syntax/tmap_only.md
@@ -1,0 +1,14 @@
+# TMAP8-only Input File Syntax
+
+Listed below are all the reference pages for TMAP8 specific code that
+can be used in the TMAP8 input file.
+
+Click the blue links in the class names shown below to view the detailed
+description, the class purpose, theoretical models, input file examples, and
+references.
+
+Click the blue icon link shown to the right of each main class type heading
+(e.g. Adaptivity) to see a more detailed description of the class type purpose
+within TMAP8.
+
+!syntax complete groups=TMAPApp

--- a/doc/sqa_reports.yml
+++ b/doc/sqa_reports.yml
@@ -2,6 +2,7 @@ Applications:
     tmap:
         app_types:
             - TMAPApp
+        exe_name: tmap
         content_directory: ${ROOT_DIR}/doc/content
         remove:
             - ${MOOSE_DIR}/framework/doc/remove.yml

--- a/doc/sqa_reports.yml
+++ b/doc/sqa_reports.yml
@@ -1,0 +1,26 @@
+Applications:
+    tmap:
+        app_types:
+            - TMAPApp
+        content_directory: ${ROOT_DIR}/doc/content
+        remove:
+            - ${MOOSE_DIR}/framework/doc/remove.yml
+        log_default: WARNING
+        show_warning: false
+
+Documents:
+    software_requirements_specification: sqa/tmap_srs.md
+    software_design_description: sqa/tmap_sdd.md
+    software_test_plan: sqa/tmap_stp.md
+    requirements_traceablity_matrix: sqa/tmap_rtm.md
+    verification_validation_report: sqa/tmap_vvr.md
+    failure_analysis_report: sqa/tmap_far.md
+    log_default: WARNING
+    show_warning: false
+
+Requirements:
+    tmap:
+        directories:
+            - ${ROOT_DIR}/test
+        log_default: WARNING
+        show_warning: false

--- a/doc/sqa_tmap.yml
+++ b/doc/sqa_tmap.yml
@@ -4,6 +4,4 @@ specs:
     - tests
 dependencies:
     - framework
-repos:
-    default: https://github.com/idaholab/TMAP8.git (push)
 reports: !include ${ROOT_DIR}/doc/sqa_reports.yml

--- a/doc/sqa_tmap.yml
+++ b/doc/sqa_tmap.yml
@@ -1,0 +1,9 @@
+directories:
+    - ${ROOT_DIR}/test/tests
+specs:
+    - tests
+dependencies:
+    - framework
+repos:
+    default: https://github.com/idaholab/TMAP8.git (push)
+reports: !include ${ROOT_DIR}/doc/sqa_reports.yml


### PR DESCRIPTION
Still need to make an issue for this, but I implemented the basic infrastructure for MooseDocs and SQA last night in preparation for our meeting today. This PR: 

- Updates the MOOSE submodule
- Adds the SQA extension and YAML objects to generate a minimal website
- Adds basic stub documentation pages for existing TMAP8 objects
- Adds website links to SQA summary, a TMAP8-only documentation page, and a complete (TMAP + MOOSE) documentation page

Closes #6