### PR TITLE
Fixup PETSc options in diagonal-ncp-lm-nodal-enforcement input

### DIFF
--- a/test/tests/ncp-lms/README.md
+++ b/test/tests/ncp-lms/README.md
@@ -145,6 +145,27 @@ Postprocessor Values:
 |   1.000000e+01 |   5.800000e+01 |   3.400000e+01 |
 +----------------+----------------+----------------+
 
+EDIT 11-07-2021 (cticenhour, see issue #16)
+Removal of PETSc option `-snes_max_linear_solve_fail 0` from input leads to the
+following revised postprocessor output, but fixes failing threaded testing (failed
+to converge by 5th timestep):
+
++----------------+----------------+----------------+
+| time           | active_lm      | violations     |
++----------------+----------------+----------------+
+|   0.000000e+00 |   0.000000e+00 |   0.000000e+00 |
+|   1.000000e+00 |   3.000000e+00 |   0.000000e+00 |
+|   2.000000e+00 |   1.200000e+01 |   9.000000e+00 |
+|   3.000000e+00 |   2.100000e+01 |   1.800000e+01 |
+|   4.000000e+00 |   3.100000e+01 |   3.000000e+01 |
+|   5.000000e+00 |   3.900000e+01 |   3.700000e+01 |
+|   6.000000e+00 |   4.600000e+01 |   4.100000e+01 |
+|   7.000000e+00 |   5.100000e+01 |   4.600000e+01 |
+|   8.000000e+00 |   5.400000e+01 |   5.100000e+01 |
+|   9.000000e+00 |   5.600000e+01 |   5.700000e+01 |
+|   1.000000e+01 |   5.800000e+01 |   4.900000e+01 |
++----------------+----------------+----------------+
+
 ## diagonal-ncp-lm-nodal-enforcement-nodal-forces.i I
 
 - Second order primal, second order LM

--- a/test/tests/ncp-lms/README.md
+++ b/test/tests/ncp-lms/README.md
@@ -145,27 +145,6 @@ Postprocessor Values:
 |   1.000000e+01 |   5.800000e+01 |   3.400000e+01 |
 +----------------+----------------+----------------+
 
-EDIT 11-07-2021 (cticenhour, see issue #16)
-Removal of PETSc option `-snes_max_linear_solve_fail 0` from input leads to the
-following revised postprocessor output, but fixes failing threaded testing (failed
-to converge by 5th timestep):
-
-+----------------+----------------+----------------+
-| time           | active_lm      | violations     |
-+----------------+----------------+----------------+
-|   0.000000e+00 |   0.000000e+00 |   0.000000e+00 |
-|   1.000000e+00 |   3.000000e+00 |   0.000000e+00 |
-|   2.000000e+00 |   1.200000e+01 |   9.000000e+00 |
-|   3.000000e+00 |   2.100000e+01 |   1.800000e+01 |
-|   4.000000e+00 |   3.100000e+01 |   3.000000e+01 |
-|   5.000000e+00 |   3.900000e+01 |   3.700000e+01 |
-|   6.000000e+00 |   4.600000e+01 |   4.100000e+01 |
-|   7.000000e+00 |   5.100000e+01 |   4.600000e+01 |
-|   8.000000e+00 |   5.400000e+01 |   5.100000e+01 |
-|   9.000000e+00 |   5.600000e+01 |   5.700000e+01 |
-|   1.000000e+01 |   5.800000e+01 |   4.900000e+01 |
-+----------------+----------------+----------------+
-
 ## diagonal-ncp-lm-nodal-enforcement-nodal-forces.i I
 
 - Second order primal, second order LM

--- a/test/tests/ncp-lms/diagonal-ncp-lm-nodal-enforcement.i
+++ b/test/tests/ncp-lms/diagonal-ncp-lm-nodal-enforcement.i
@@ -156,8 +156,8 @@ dt=1
   dt = ${dt}
   dtmin = ${dt}
   solve_type = NEWTON
-  petsc_options_iname = '-ksp_max_it -pc_factor_levels'
-  petsc_options_value = '30          16'
+  petsc_options_iname = '-snes_max_linear_solve_fail -ksp_max_it -pc_factor_levels -ksp_gmres_restart'
+  petsc_options_value = '0                           60          16                60'
 []
 
 [Outputs]

--- a/test/tests/ncp-lms/diagonal-ncp-lm-nodal-enforcement.i
+++ b/test/tests/ncp-lms/diagonal-ncp-lm-nodal-enforcement.i
@@ -156,8 +156,8 @@ dt=1
   dt = ${dt}
   dtmin = ${dt}
   solve_type = NEWTON
-  petsc_options_iname = '-snes_max_linear_solve_fail -ksp_max_it -pc_factor_levels'
-  petsc_options_value = '0                           30          16'
+  petsc_options_iname = '-ksp_max_it -pc_factor_levels'
+  petsc_options_value = '30          16'
 []
 
 [Outputs]


### PR DESCRIPTION
Closes #16

This change passes thread testing on my MacOS workstation, and doesn't seem to impact the results of any other test. @lindsayad do you happen to remember why you set `snes_max_linear_solve_fail` to zero here, and do you suggest an alternative change that might better fit the intent of the test? 