### PR TITLE
Add initial TMAP8 workshop/tutorial slides

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -17,6 +17,7 @@ Extensions:
             Documentation:
               TMAP8-only Syntax: syntax/tmap_only.md
               Complete Code Syntax: syntax/index.md
+              TMAP8 Tutorial Slides: tutorial/index.md
             Software Quality: /sqa/index.md
     MooseDocs.extensions.appsyntax:
         executable: ${ROOT_DIR}

--- a/doc/tutorial_config.yml
+++ b/doc/tutorial_config.yml
@@ -1,0 +1,35 @@
+Content:
+    tutorial:
+        root_dir: ${ROOT_DIR}/doc/workshops
+
+Executioner:
+    type: MooseDocs.base.Serial
+
+Renderer:
+    type: MooseDocs.base.RevealRenderer
+    theme: simple
+
+Extensions:
+    disable_defaults: True
+    MooseDocs.extensions.reveal:
+        translate: tutorial/index.md
+    MooseDocs.extensions.comment: default
+    MooseDocs.extensions.command: default
+    MooseDocs.extensions.core: default
+    MooseDocs.extensions.config: default
+    MooseDocs.extensions.media: default
+    MooseDocs.extensions.floats: default
+    MooseDocs.extensions.include: default
+    MooseDocs.extensions.style: default
+    MooseDocs.extensions.autolink: default
+    MooseDocs.extensions.materialicon: default
+    MooseDocs.extensions.heading: default
+    MooseDocs.extensions.shortcut: default
+    MooseDocs.extensions.table: default
+    MooseDocs.extensions.layout: default
+    MooseDocs.extensions.content: default
+    MooseDocs.extensions.modal: default
+    MooseDocs.extensions.listing: default
+    MooseDocs.extensions.datetime: default
+    MooseDocs.extensions.katex:
+        macros: !include ${MOOSE_DIR}/modules/doc/katex_macros.yml

--- a/doc/workshops/tutorial/content/moose_intro.md
+++ b/doc/workshops/tutorial/content/moose_intro.md
@@ -1,0 +1,72 @@
+# Introduction to MOOSE
+
+!---
+
+# MOOSE Framework: Overview
+
+!row!
+!col! width=50%
+
+!media large_media/tutorials/darcy_thermo_mech/moose_intro.png
+
+!col-end!
+
+!col! width=50%
+
+- Developed by Idaho National Laboratory since 2008
+- Used for studying and analyzing nuclear reactor problems
+- Free and open source (LGPLv2 license)
+- Large user community
+- Highly parallel and HPC capable
+- Developed and supported by full time INL staff - long-term support
+- https://www.mooseframework.inl.gov
+
+!col-end!
+!row-end!
+
+!---
+
+# MOOSE Framework: Key features
+
+!row!
+!col! width=50%
+
+!media large_media/tutorials/darcy_thermo_mech/moose_intro.png
+
+!col-end!
+
+!col! width=50%
+
+- Massively parallel computation - successfully run on >100,000 processor cores
+- Multiphysics solve capability - fully coupled and implicit solver
+- Multiscale solve capability - multiple application can perform computation for a problem simultaneously
+- Provides high level interface to implement customized physics, geometries, boundary conditions, and material models
+- Initially developed to support nuclear R&D but now widely used for non-nuclear R&D also
+
+!col-end!
+!row-end!
+
+!---
+
+# MOOSE Framework: Applications
+
+!media large_media/tutorials/darcy_thermo_mech/moose_herd_2019.png style=width:100%;margin-left:auto;margin-right:auto;display:block;
+
+!---
+
+# MOOSE Framework: Solving specific physics
+
+!row!
+!col! width=70%
+
+!media large_media/tutorials/darcy_thermo_mech/moose_code.png
+
+!col-end!
+
+!col! width=30%
+
+- Custom "kernels" representing specific physics
+- They can be developed easily and incorporated into the simulation
+
+!col-end!
+!row-end!

--- a/doc/workshops/tutorial/content/outro.md
+++ b/doc/workshops/tutorial/content/outro.md
@@ -1,0 +1,4 @@
+# Concluding Remarks
+
+- Feedback/Q&A/Comments
+- Discussion of future collaborations/communications

--- a/doc/workshops/tutorial/content/tmap8_v_and_v.md
+++ b/doc/workshops/tutorial/content/tmap8_v_and_v.md
@@ -1,0 +1,6 @@
+# TMAP8 Verification & Validation
+
+!style halign=center
+TMAP4 and TMAP7 verification and validation cases are being added and documented in TMAP8
+
+- [https://mooseframework.inl.gov/TMAP8/](https://mooseframework.inl.gov/TMAP8/)

--- a/doc/workshops/tutorial/content/tmap8_vs_legacy.md
+++ b/doc/workshops/tutorial/content/tmap8_vs_legacy.md
@@ -1,0 +1,16 @@
+# TMAP8 vs Legacy TMAP (TMAP4, TMAP7)
+
+- TMAP8 directly inherits all of MOOSE's features
+
+  - Easy to use and customize
+  - Takes advantage of high performance computing by default
+  - Developed and supported by full time INL staff - long-term support
+  - Massively parallel computation
+  - Multiphysics solve capability
+  - Multiscale solve capability - multiple applications can perform computation for a problem simultaneously
+  - Provides high-level interface to implement customized physics, geometries, boundary conditions, and material models
+
+    - Enables 2D and 3D simulations
+
+  - The capabilities/physics in TMAP4 are added to TMAP8
+  - The addition of TMAP7 capabilities are in progress

--- a/doc/workshops/tutorial/content/tutorial_getting_started.md
+++ b/doc/workshops/tutorial/content/tutorial_getting_started.md
@@ -1,0 +1,17 @@
+# Getting Started with TMAP8
+
+!---
+
+# How to install TMAP8
+
+1. Go to [https://mooseframework.inl.gov/TMAP8/](https://mooseframework.inl.gov/TMAP8/)
+2. Click on Getting Started and following instructions
+3. Help for troubleshooting is available at the bottom of the page
+
+!---
+
+# Run a verification case
+
+- Go to [https://mooseframework.inl.gov/TMAP8/](https://mooseframework.inl.gov/TMAP8/)
+- Edit input files with VSCode: [https://code.visualstudio.com](https://code.visualstudio.com)
+- `mpirun -np 2 ~/projects/TMAP8/tmap8-opt -i inputname.i`

--- a/doc/workshops/tutorial/index.md
+++ b/doc/workshops/tutorial/index.md
@@ -1,0 +1,49 @@
+# Tritium Migration Analysis Program, Version 8 (TMAP8) Tutorial
+
+!style halign=center fontsize=120%
+!datetime today format=%B %Y
+
+!---
+
+# Outline of the meeting
+
+- Introductions
+- Introduction to MOOSE
+
+  - Overview
+  - Key features
+  - Applications
+  - Solving specific physics
+
+- TMAP8 vs Legacy TMAP (TMAP4, TMAP7)
+- TMAP8 Verification & Validation
+- Getting started with TMAP8
+
+  - How to install
+  - Run a verification case
+
+- Concluding Remarks (Q&A, Feedback, Future discussions)
+
+!---
+
+!include moose_intro.md
+
+!---
+
+!include tmap8_vs_legacy.md
+
+!---
+
+!include tmap8_v_and_v.md
+
+!---
+
+!include tutorial_getting_started.md
+
+!---
+
+!include outro.md
+
+!---
+
+!media large_media/framework/inl_blue.png style=width:50%;margin-left:auto;margin-right:auto;display:block;


### PR DESCRIPTION
This PR adds initial infrastructure for a set of TMAP8 tutorial slides, based on the slide draft for the most recent TMAP8 tutorial sent to me by @simopier. 

The file structure set up here also allows for multiple kinds of workshops to be setup inside of the `doc/workshops` directory tree.

Closes #28 