### PR TITLE
Fix broken TMAP8 SQA 

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -16,6 +16,7 @@ Content:
         content:
             - media/*
             - application_usage/command_line_usage.md
+            - application_usage/restart_recover.md
 Renderer:
     type: MooseDocs.base.MaterializeRenderer
 Extensions:


### PR DESCRIPTION
This fixes the broken build by adding `restart_recover.md` to the Content listing in `config.yml`

Refs #47, as the submodule update triggered the need for the additional content. 