### PR TITLE
Add PhysicalConstant namespace to use consistent values

### DIFF
--- a/include/bcs/EquilibriumBC.h
+++ b/include/bcs/EquilibriumBC.h
@@ -35,9 +35,6 @@ protected:
   /// The temperature (K)
   const ADVariableValue & _T;
 
-  /// Ideal gas constant (J/K-mol)
-  const Real _R;
-
   /// The number of atoms that compose our arbitrary unit for quantity
   const Real _var_scaling_factor;
 };

--- a/include/utils/PhysicalConstants.h
+++ b/include/utils/PhysicalConstants.h
@@ -11,7 +11,7 @@
 namespace PhysicalConstants
 {
 // Physical constants
-// Avogadro's number (at/mol)
+// Avogadro's number (atoms/mol)
 // https://physics.nist.gov/cgi-bin/cuu/Value?na|search_for=Avogadro
 const auto avogadro_number = 6.02214076e23;
 // Boltzmann constant (J/K)
@@ -20,10 +20,10 @@ const auto boltzmann_constant = 1.380649e-23;
 // Conversion coefficient from eV to Joules
 // https://physics.nist.gov/cgi-bin/cuu/Value?Revj|search_for=joules
 const auto eV_to_J = 1.602176634e-19;
-// Ideal gas constant (J/(mol-K))
+// Ideal gas constant (J/K/mol)
 // https://physics.nist.gov/cgi-bin/cuu/Value?eqr
 const auto ideal_gas_constant = 8.31446261815324;
-// Stefan-Boltzmann constant (W/(m2-K))
+// Stefan-Boltzmann constant (W/m^2/K^4)
 // https://physics.nist.gov/cgi-bin/cuu/Value?sigma|search_for=Stefan-Boltzmann
 const auto stefan_boltzmann_constant = 5.670374419e-8;
 } // namespace PhysicalConstants

--- a/include/utils/PhysicalConstants.h
+++ b/include/utils/PhysicalConstants.h
@@ -1,0 +1,29 @@
+/************************************************************/
+/*                DO NOT MODIFY THIS HEADER                 */
+/*   TMAP8: Tritium Migration Analysis Program, Version 8   */
+/*                                                          */
+/*   Copyright 2021 - 2023 Battelle Energy Alliance, LLC    */
+/*                   ALL RIGHTS RESERVED                    */
+/************************************************************/
+
+#pragma once
+
+namespace PhysicalConstants
+{
+// Physical constants
+// Avogadro's number (at/mol)
+// https://physics.nist.gov/cgi-bin/cuu/Value?na|search_for=Avogadro
+const auto avogadro_number = 6.02214076e23;
+// Boltzmann constant (J/K)
+// https://physics.nist.gov/cgi-bin/cuu/Value?k|search_for=Boltzmann
+const auto boltzmann_constant = 1.380649e-23;
+// Conversion coefficient from eV to Joules
+// https://physics.nist.gov/cgi-bin/cuu/Value?Revj|search_for=joules
+const auto eV_to_J = 1.602176634e-19;
+// Ideal gas constant (J/(mol-K))
+// https://physics.nist.gov/cgi-bin/cuu/Value?eqr
+const auto ideal_gas_constant = 8.31446261815324;
+// Stefan-Boltzmann constant (W/(m2-K))
+// https://physics.nist.gov/cgi-bin/cuu/Value?sigma|search_for=Stefan-Boltzmann
+const auto stefan_boltzmann_constant = 5.670374419e-8;
+} // namespace PhysicalConstants

--- a/src/bcs/EquilibriumBC.C
+++ b/src/bcs/EquilibriumBC.C
@@ -7,6 +7,7 @@
 /************************************************************/
 
 #include "EquilibriumBC.h"
+#include "PhysicalConstants.h"
 
 registerMooseObject("TMAPApp", EquilibriumBC);
 
@@ -38,7 +39,6 @@ EquilibriumBC::EquilibriumBC(const InputParameters & parameters)
     _p(getParam<Real>("p")),
     _enclosure_var(adCoupledScalarValue("enclosure_scalar_var")),
     _T(adCoupledValue("temp")),
-    _R(8.314),
     _var_scaling_factor(getParam<Real>("var_scaling_factor"))
 {
 }
@@ -46,6 +46,6 @@ EquilibriumBC::EquilibriumBC(const InputParameters & parameters)
 ADReal
 EquilibriumBC::computeQpResidual()
 {
-  ADReal K = _Ko * std::exp(-1.0 * _Ea / (_R * _T[0]));
+  ADReal K = _Ko * std::exp(-1.0 * _Ea / (PhysicalConstants::ideal_gas_constant * _T[0]));
   return (_u * _var_scaling_factor - K * std::pow(_enclosure_var[0], _p));
 }

--- a/src/interfacekernels/InterfaceSorptionSievert.C
+++ b/src/interfacekernels/InterfaceSorptionSievert.C
@@ -82,7 +82,7 @@ InterfaceSorptionSievertTempl<is_ad>::computeQpResidual(Moose::DGResidualType ty
   const GenericReal<is_ad> u_neighbor =
       std::max(small, _unit_scale_neighbor * _neighbor_value[_qp]);
   const GenericReal<is_ad> temperature_limited = std::max(small, _T[_qp]);
-  const auto R = PhysicalConstants::ideal_gas_constant; // ideal gas constant (W/(m2-K))
+  const auto R = PhysicalConstants::ideal_gas_constant; // ideal gas constant (J/K/mol)
 
   GenericReal<is_ad> r = 0; // residual
 
@@ -118,7 +118,7 @@ InterfaceSorptionSievertTempl<false>::computeQpJacobian(Moose::DGJacobianType ty
   const Real small = 1.0e-20;
   const Real u_neighbor = std::max(small, _unit_scale_neighbor * _neighbor_value[_qp]);
   const Real temperature_limited = std::max(small, _T[_qp]);
-  const auto R = PhysicalConstants::ideal_gas_constant; // ideal gas constant (W/(m2-K))
+  const auto R = PhysicalConstants::ideal_gas_constant; // ideal gas constant (J/K/mol)
 
   Real jac = 0; // jacobian
 

--- a/src/interfacekernels/InterfaceSorptionSievert.C
+++ b/src/interfacekernels/InterfaceSorptionSievert.C
@@ -7,6 +7,7 @@
 /************************************************************/
 
 #include "InterfaceSorptionSievert.h"
+#include "PhysicalConstants.h"
 
 registerMooseObject("TMAPApp", InterfaceSorptionSievert);
 registerMooseObject("TMAPApp", ADInterfaceSorptionSievert);
@@ -81,7 +82,7 @@ InterfaceSorptionSievertTempl<is_ad>::computeQpResidual(Moose::DGResidualType ty
   const GenericReal<is_ad> u_neighbor =
       std::max(small, _unit_scale_neighbor * _neighbor_value[_qp]);
   const GenericReal<is_ad> temperature_limited = std::max(small, _T[_qp]);
-  const auto R = 8.31446261815324; // ideal gas constant (W/(m2-K))
+  const auto R = PhysicalConstants::ideal_gas_constant; // ideal gas constant (W/(m2-K))
 
   GenericReal<is_ad> r = 0; // residual
 
@@ -117,7 +118,7 @@ InterfaceSorptionSievertTempl<false>::computeQpJacobian(Moose::DGJacobianType ty
   const Real small = 1.0e-20;
   const Real u_neighbor = std::max(small, _unit_scale_neighbor * _neighbor_value[_qp]);
   const Real temperature_limited = std::max(small, _T[_qp]);
-  const auto R = 8.31446261815324; // ideal gas constant (W/(m2-K))
+  const auto R = PhysicalConstants::ideal_gas_constant; // ideal gas constant (W/(m2-K))
 
   Real jac = 0; // jacobian
 


### PR DESCRIPTION
- Create PhysicalConstants namespace
- Update existing classes to use PhysicalConstants.h
    
(Close #54)