### PR TITLE
Remove irrelevant notes from documentation

### DIFF
--- a/doc/content/verification/ver-1b.md
+++ b/doc/content/verification/ver-1b.md
@@ -53,18 +53,6 @@ results are shown in []
     caption=Comparison of flux as function of time at x\=0.5m calculated through
     TMAP8 and analytically
 
-### Notes
-
-The trapping test features some oscillations in the solution for whatever
-reason. In order for the oscillations to not take over the simulation, it seems
-that the ratio of the **inverse of the Fourier number** must be kept
-sufficiently high, e.g. `h^2 / (D * dt)`. Included in this directory are three
-`png` files that show the permeation for different `h` and `dt` values. They are
-summarized below:
-
-- `nx-80.png`: `nx = 80` and `dt = .0625`
-- `nx-40.png`: `nx = 40` and `dt = .25`
-- `nx-20.png`: `nx = 20` and `dt = 1`
 
 The oscillations in the permeation graph go away with increasing fineness in the
 mesh and in `dt`.


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
I noticed in the documentation of ver-1b the notes section was irrelevant to the problem since it has no traps.
It may be a copy paste from ver-1d.

## Design
Remove the irrelevant notes from ver-1b

## Impact
Improved user experience when reading documentation


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
