### PR TITLE
Remove duplicate bib warnings

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -76,7 +76,10 @@ Extensions:
     MooseDocs.extensions.template:
         active: true
     MooseDocs.extensions.bibtex:
-        duplicates: !include ${MOOSE_DIR}/modules/doc/duplicate_bibs.yml
+        duplicates:
+            - hales15homogenization
+            - kim_phase-field_1999
+            - incropera2002
     MooseDocs.extensions.civet:
         test_results_cache: '/tmp/civet/jobs'
         branch: main


### PR DESCRIPTION
## Reason
Rather than using the MOOSE duplicate bibs file, single out the individual duplicates warned about during documentation builds. This needs to be done because `incropera2002` was introduced in #125, and this doesn't exist as a named duplicate in the main MOOSE file. 

## Design
Switch from including a duplicates list to only naming the ones TMAP8 warns about. 

## Impact
No user-facing change. Removal of confusing documentation warning for `incropera2002`. 
