### PR TITLE
Documentation adjustments to support FENIX

### DIFF
--- a/doc/content/verification_and_validation/index.md
+++ b/doc/content/verification_and_validation/index.md
@@ -2,7 +2,7 @@ For [software quality assurance](sqa/index.md) purposes, TMAP8 undergoes verific
 
 Note that in addition to monitoring TMAP8 performance and reproducibility in verification and validation cases, the effects of changes made to TMAP8 are tracked. A series of automated tests are performed via continuous integration using [CIVET](https://civet.inl.gov/repo/530) to help identify any changes in TMAP8's predictions, therefore ensuring stability and robustness.
 
-TMAP8 also contains [example cases](examples/index.md), which showcase how TMAP8 can be used. Finally, for more references of TMAP8 usage, a list of publications supporting TMAP8 development can be found [here](publications.md).
+TMAP8 also contains [example cases](examples/tmap_index.md), which showcase how TMAP8 can be used. Finally, for more references of TMAP8 usage, a list of publications supporting TMAP8 development can be found [here](publications.md).
 
 # List of verification cases
 

--- a/doc/sqa_tmap8.yml
+++ b/doc/sqa_tmap8.yml
@@ -4,4 +4,15 @@ specs:
     - tests
 dependencies:
     - framework
+    - heat_transfer
+    - ray_tracing
+    - navier_stokes
+    - thermal_hydraulics
+    - fluid_properties
+    - rdg
+    - scalar_transport
+    - solid_properties
+    - misc
+    - phase_field
+    - solid_mechanics
 reports: !include ${ROOT_DIR}/doc/sqa_reports.yml


### PR DESCRIPTION
Closes #152 

This also adds dependencies in the `sqa_tmap8.yml` file. These were missing, and resulted in technically incomplete SQA documentation.