### PR TITLE
Fix a typo in Documentation of "Using TMAP8"

### DIFF
--- a/doc/content/getting_started/using_tmap8.md
+++ b/doc/content/getting_started/using_tmap8.md
@@ -5,7 +5,7 @@
 !style halign=left
 After TMAP8 is installed and tested, you should now be able to run input files
 using the `tmap8-opt` executable located at `~/projects/TMAP8`. Input files
-demonstrating the capabilities of TMAP8 can be found in `~/projects/test/tests`.
+demonstrating the capabilities of TMAP8 can be found in `~/projects/TMAP8/test/tests`.
 Any input file (say, one called `example_input.i`) can be run with the following
 basic syntax:
 


### PR DESCRIPTION
- Update the typo, ~/projects/test/tests, with ~/projects/TMP8/test/tests

(Refs. #159)

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->