### PR TITLE
Updating typos in equations

### DIFF
--- a/doc/content/verification_and_validation/ver-1a.md
+++ b/doc/content/verification_and_validation/ver-1a.md
@@ -91,7 +91,7 @@ where $x=l$ is the position of the surface in contact with the enclosure, and $x
 \end{equation}
 and $\alpha_n$ are the roots of
 \begin{equation}
-    \alpha_n = \frac{L}{tan \ \alpha_n}.
+    \alpha_n = \frac{L}{tan (\alpha_n l)}.
 \end{equation}
 
 By linking the concentration on the surface of the slab in contact with the enclosure ($x=l$ as used in [!cite](ambrosek2008verification)) with the pressure of the enclosure, Henry's law provides

--- a/doc/content/verification_and_validation/ver-1ja.md
+++ b/doc/content/verification_and_validation/ver-1ja.md
@@ -21,11 +21,11 @@ The evolution of the tritium and helium concentration, $C_T$ and $C_{He}$, respe
 are governed by
 
 \begin{equation}
-    \frac{d C_T}{dt} = -k,
+    \frac{d C_T}{dt} = -k C_T,
 \end{equation}
 and
 \begin{equation}
-    \frac{d C_{He}}{dt} = kt,
+    \frac{d C_{He}}{dt} = k C_T,
 \end{equation}
 where $t$ is the time in seconds, concentrations are in atoms/m$^3$, and $k= 0.693/t_{1/2}$ is the decay rate constant in 1/s.
 


### PR DESCRIPTION
 - Add "l" for \alpha_n equation of TMAP7 in ver1a, and update the first two equations of ver1ja

(Ref. #161)
