### PR TITLE
Address bug in fuel_cycle_gui.py script

### DIFF
--- a/test/tests/fuel-cycle/fuel_cycle_gui.py
+++ b/test/tests/fuel-cycle/fuel_cycle_gui.py
@@ -296,6 +296,17 @@ class fuel_cycle_form(tk.Tk):
 
     def buttonClick(self):
         output_string = ""
+        for label, x in zip(self.matches, self.input_entries):
+            try:
+                self.labeldict[label[1][0]]=float(x.get())
+            except ValueError:
+                x_str = x.get()
+                try:
+                    self.labeldict[label[1][0]]=float(x.get().replace('e','').replace('-',''))
+                except ValueError:
+                    raise ValueError('Non-numeric value in parameter definition during creation')
+                    self.destroy()
+
         output_string = self.apply_template(self.labeldict)
         with open(self.tmpfile,'w') as outfile:
             outfile.write(output_string)


### PR DESCRIPTION
Obtain values of input parameters at runtime as part of the workflow created by the 'buttonClick' method in the fuel_cycle_gui.py script. #closes #215

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
