### PR TITLE
Make sure all properties are output in case of a mix of 'output_material_properties'

### DIFF
--- a/test/tests/val-2b/val-2b.i
+++ b/test/tests/val-2b/val-2b.i
@@ -250,6 +250,7 @@ node_length_Be = ${fparse length_Be_modeled / num_nodes_Be}
     type = MaterialADConverter
     ad_props_in = 'diffusivity_Be diffusivity_BeO'
     reg_props_out = 'diffusivity_Be_nonAD diffusivity_BeO_nonAD'
+    outputs = all
   []
   [interface_jump]
     type = SolubilityRatioMaterial
@@ -258,6 +259,7 @@ node_length_Be = ${fparse length_Be_modeled / num_nodes_Be}
     boundary = interface
     concentration_primary = deuterium_concentration_BeO
     concentration_secondary = deuterium_concentration_Be
+    outputs = all
   []
 []
 


### PR DESCRIPTION
We should not need to do that so something is probably up with Outputs/exodus/output_material_properties

and outputs = 'all' parameters. I posted on the moose PR that changed this

refs idaholab/moose#23550

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
