### PR TITLE
Add vtk requirements

### DIFF
--- a/test/tests/pore_scale_transport/tests
+++ b/test/tests/pore_scale_transport/tests
@@ -13,6 +13,7 @@
                 Outputs/exodus/execute_on='INITIAL TIMESTEP_END FINAL'"
     exodiff = pore_structure_closed_slice/pore_structure_closed_slice.e
     requirement = 'The system shall be able to read a microstructure image and import it to perform a simulation to smoothen the interfaces.'
+    capabilities = 'vtk'
   []
   [pore_scale_transport_slice]
     type = Exodiff


### PR DESCRIPTION
Adding a requirement check for VTK, for test:

pore_scale_transport.pore_scale_microstructure_formation_slice

Closes: #256

