### PR TITLE
Add TMAP8 logo on workshop slides

### DIFF
--- a/doc/workshops/tutorial/index.md
+++ b/doc/workshops/tutorial/index.md
@@ -3,7 +3,7 @@
 !style halign=center fontsize=120%
 !datetime today format=%B %Y
 
-!media figures/TMAP8_logo_blue.png style=display:block;margin-left:auto;margin-right:auto;width:30%;
+!media figures/TMAP8_logo_blue.png style=display:block;box-shadow:none;margin-left:auto;margin-right:auto;width:30%;
 
 !style halign=center
 [https://mooseframework.inl.gov/TMAP8/](https://mooseframework.inl.gov/TMAP8/)


### PR DESCRIPTION
(Refs. #297)

@cticenhour, do you know how to NOT make an image stand out of the page with shadows and all? 
I wanted to have it directly on the page but cannot figure it out. 
