### PR TITLE
Update for MetaPhysicl 2.0

### DIFF
--- a/src/bcs/EquilibriumBC.C
+++ b/src/bcs/EquilibriumBC.C
@@ -84,6 +84,8 @@ EquilibriumBC::EquilibriumBC(const InputParameters & parameters)
 ADReal
 EquilibriumBC::computeQpResidual()
 {
+  using std::exp;
+  using std::pow;
   ADReal Ko, Ea;
   // Use the functors if a subdomain has been provided for the nodal evaluation
   if (_subdomain != Moose::INVALID_BLOCK_ID)
@@ -103,9 +105,9 @@ EquilibriumBC::computeQpResidual()
 
   ADReal K;
   if (_T)
-    K = Ko * std::exp(-Ea / (PhysicalConstants::ideal_gas_constant * (*_T)[0]));
+    K = Ko * exp(-Ea / (PhysicalConstants::ideal_gas_constant * (*_T)[0]));
   else
-    K = Ko * std::exp(-Ea / (PhysicalConstants::ideal_gas_constant *
-                             _T_function->value(_t, *_current_node)));
-  return (_u * _var_scaling_factor - _K_scaling_factor * K * std::pow(_enclosure_var[0], _p));
+    K = Ko *
+        exp(-Ea / (PhysicalConstants::ideal_gas_constant * _T_function->value(_t, *_current_node)));
+  return (_u * _var_scaling_factor - _K_scaling_factor * K * pow(_enclosure_var[0], _p));
 }

--- a/src/interfacekernels/ADMatInterfaceReactionYHxPCT.C
+++ b/src/interfacekernels/ADMatInterfaceReactionYHxPCT.C
@@ -47,6 +47,10 @@ ADMatInterfaceReactionYHxPCT::ADMatInterfaceReactionYHxPCT(const InputParameters
 ADReal
 ADMatInterfaceReactionYHxPCT::computeQpResidual(Moose::DGResidualType type)
 {
+  using std::exp;
+  using std::log;
+  using std::max;
+  using std::pow;
   ADReal r = 0;
 
   // Calculate the equilibrium concentration value based on PCT curve
@@ -55,8 +59,8 @@ ADMatInterfaceReactionYHxPCT::computeQpResidual(Moose::DGResidualType type)
       PhysicalConstants::ideal_gas_constant * _neighbor_temperature[_qp] * _neighbor_value[_qp] / 2;
 
   // Calculate the value of the pressures for the phase transition plateau (pressure in Pa)
-  auto limit_pressure = std::exp(-26.1 + 3.88e-2 * _neighbor_temperature[_qp] -
-                                 9.7e-6 * Utility::pow<2>(_neighbor_temperature[_qp]));
+  auto limit_pressure = exp(-26.1 + 3.88e-2 * _neighbor_temperature[_qp] -
+                            9.7e-6 * Utility::pow<2>(_neighbor_temperature[_qp]));
 
   // return warning if the PCT curves is used out of bounds (pressure in Pa)
   if (!_silence_warnings && ((neighbor_pressure < limit_pressure) || (neighbor_pressure > 1.e6)))
@@ -69,10 +73,9 @@ ADMatInterfaceReactionYHxPCT::computeQpResidual(Moose::DGResidualType type)
 
   // Calculate the atomic fraction based on the PCT curve
   auto atomic_fraction =
-      2. -
-      std::pow(1. + std::exp(21.6 - 0.0225 * _neighbor_temperature[_qp] +
-                             (-0.0445 + 7.18e-4 * _neighbor_temperature[_qp]) *
-                                 (std::log(std::max(neighbor_pressure - limit_pressure, 1e-10)))),
+      2. - pow(1. + exp(21.6 - 0.0225 * _neighbor_temperature[_qp] +
+                        (-0.0445 + 7.18e-4 * _neighbor_temperature[_qp]) *
+                            (log(max(neighbor_pressure - limit_pressure, 1e-10)))),
                -1);
 
   // Convert to concentration

--- a/src/interfacekernels/InterfaceSorption.C
+++ b/src/interfacekernels/InterfaceSorption.C
@@ -88,12 +88,12 @@ template <bool is_ad>
 GenericReal<is_ad>
 InterfaceSorptionTempl<is_ad>::computeQpResidual(Moose::DGResidualType type)
 {
+  using std::max;
   // restrict inputs to physically meaningful values to avoid encountering NANs during linear solve
   const auto small = 1.0e-20;
-  const GenericReal<is_ad> u = std::max(small, _unit_scale * _u[_qp]);
-  const GenericReal<is_ad> u_neighbor =
-      std::max(small, _unit_scale_neighbor * _neighbor_value[_qp]);
-  const GenericReal<is_ad> temperature_limited = std::max(small, _T[_qp]);
+  const GenericReal<is_ad> u = max(small, _unit_scale * _u[_qp]);
+  const GenericReal<is_ad> u_neighbor = max(small, _unit_scale_neighbor * _neighbor_value[_qp]);
+  const GenericReal<is_ad> temperature_limited = max(small, _T[_qp]);
   const auto R = PhysicalConstants::ideal_gas_constant; // ideal gas constant (J/K/mol)
 
   GenericReal<is_ad> residual = 0.;
@@ -105,9 +105,11 @@ InterfaceSorptionTempl<is_ad>::computeQpResidual(Moose::DGResidualType type)
   {
     case Moose::Element:
     {
+      using std::exp;
+      using std::pow;
       residual = _test[_i][_qp] * _sorption_penalty *
-                 (u - _K0 * std::exp(-_Ea / R / temperature_limited) *
-                          std::pow(u_neighbor * R * temperature_limited, _n_sorption));
+                 (u - _K0 * exp(-_Ea / R / temperature_limited) *
+                          pow(u_neighbor * R * temperature_limited, _n_sorption));
       break;
     }
 


### PR DESCRIPTION
Refs incoming MetaPhysicL 2.0 changes in
[idaholab/moose#31906](https://github.com/idaholab/moose/pull/31906). MetaPhysicL used to put its overloads in the std namespace which is not standard compliant. However, this is fixed in MetaPhysicL 2.0. This patch will allow both backward and forward compatibility with MetaPhysicL 1 and 2 respectively