### PR TITLE
Make val-2g comparison script more robust

### DIFF
--- a/test/tests/val-2g/comparison_val-2g.py
+++ b/test/tests/val-2g/comparison_val-2g.py
@@ -33,7 +33,7 @@ def read_csv_from_TMAP8(file_name, parameter_names):
     Returns:
         float, ndarray: the matrix keep the simulation results, first axis depended on len(parameter_names)
     """
-    if "/TMAP8/doc/" in script_folder:  # if in documentation folder
+    if "/tmap8/doc/" in script_folder.lower():  # if in documentation folder
         csv_folder = f"../../../../test/tests/val-2g/gold/{file_name}"
     else:  # if in test folder
         csv_folder = f"./gold/{file_name}"


### PR DESCRIPTION
Ensure that we properly detect whether we are in the documentation, whether the root directory is "TMAP8" or "tmap8"

Refs #357
