### PR TITLE
Fix typos in the documentation

### DIFF
--- a/doc/content/examples/divertor_monoblock/sensitivity.md
+++ b/doc/content/examples/divertor_monoblock/sensitivity.md
@@ -66,7 +66,7 @@ The top boundary tritium flux and temperature flux are both adjusted to be a fun
 ### Transient case: edge-localized mode disruption 
 
 !style halign=left
-To simulate an edge-localized mode (ELM) disruption, we simulate a set of input conditions as described in [tab:elm_transient_case]. The heat flux is much larger than the transient shutdown case, but over a shorter duration. Most of the parameters will be selected from a normal distribution, as they reflect variations around some target or estimated value. The results will be shown below in [fig:elm_correlation]. We use the same tungsten conductivy as in [!cite](Shimada2024114438), but vary the conductivity by a constant factor in the range of $\pm$5%. 
+To simulate an edge-localized mode (ELM) disruption, we simulate a set of input conditions as described in [tab:elm_transient_case]. The heat flux is much larger than the transient shutdown case, but over a shorter duration. Most of the parameters will be selected from a normal distribution, as they reflect variations around some target or estimated value. The results will be shown below in [fig:elm_correlation]. We use the same tungsten conductivity as in [!cite](Shimada2024114438), but vary the conductivity by a constant factor in the range of $\pm$5%. 
 
 !table id=tab:elm_transient_case caption=Edge-localized mode transient case parameter space.
 | Parameter | Samples | Nominal Value | Distribution | Deviation |

--- a/doc/content/examples/fuel_cycle_Abdou/index.md
+++ b/doc/content/examples/fuel_cycle_Abdou/index.md
@@ -27,7 +27,7 @@ their own ODE and tritium inventory:
 | Divertor | 4 | `T_04_DIV` | [eqn:t4] |
 | Heat Exchanger | 5 | `T_05_HX` | [eqn:t5] |
 | Coolant Purification System | 6 | `T_06_CPS` | [eqn:t6] |
-| Vaccum Pump | 7 | `T_07_vacuum` | [eqn:t7] |
+| Vacuum Pump | 7 | `T_07_vacuum` | [eqn:t7] |
 | Fuel Clean-up  | 8 | `T_08_FCU` | [eqn:t8] |
 | Isotope Separation System | 9 | `T_09_ISS` | [eqn:t9] |
 | Exhaust and Water Detritiation System | 10 | `T_10_exhaust` | [eqn:t10] |

--- a/doc/content/examples/fuel_cycle_Meschini/index.md
+++ b/doc/content/examples/fuel_cycle_Meschini/index.md
@@ -47,7 +47,7 @@ The label and corresponding equation for each systems are shown in [tritium_syst
 | Divertor                               | 4  | `T_04_DIV`      | [eqn:t4] |
 | Heat Exchanger                         | 5  | `T_05_HX`       | [eqn:t5] |
 | Detritiation System                    | 6  | `T_06_DS`       | [eqn:t6] |
-| Vaccum Pump                            | 7  | `T_07_vacuum`   | [eqn:t7] |
+| Vacuum Pump                            | 7  | `T_07_vacuum`   | [eqn:t7] |
 | Fuel Clean-up                          | 8  | `T_08_FCU`      | [eqn:t8] |
 | Isotope Separation System              | 9  | `T_09_ISS`      | [eqn:t9] |
 | Storage and Management                 | 10 | `T_10_storage`  | [eqn:t10] |

--- a/doc/content/getting_started/tmap8_user_notes.md
+++ b/doc/content/getting_started/tmap8_user_notes.md
@@ -1,7 +1,7 @@
 # TMAP8 User Notes
 
 The following page is dedicated to various notes concerning TMAP8 functionality
-that might be helpful to both new and seasoned uers. This page will be updated
+that might be helpful to both new and seasoned users. This page will be updated
 periodically, so check back often!
 
 ## Scaling id=scaling

--- a/doc/content/source/interfacekernels/ADMatInterfaceReactionZrCoHxPCT.md
+++ b/doc/content/source/interfacekernels/ADMatInterfaceReactionZrCoHxPCT.md
@@ -24,7 +24,7 @@ and $\rho$ is the zirconium-cobalt atomic density in mol/m$^3$.
        id=ZrCoHx_PCT_Data
        caption=PCT data for ZrCoHx from [!cite](jat2013hydrogen) and [!cite](nagasaki1986zirconium).
 
-To include this PCT data in TMAP8 modelling capabilites the high and low pressure regions were extracted and regressed for the resulting equations.
+To include this PCT data in TMAP8 modelling capabilities the high and low pressure regions were extracted and regressed for the resulting equations.
 
 The low pressure is captured as:
 \begin{equation}\label{eq:low_pressure}
@@ -64,7 +64,7 @@ The jump between the low low high pressure occurs if the atomic fraction is equa
 
 [/ZrCoHx_PCT.i] tests the implantation of the ZrCoHx PCT curves in TMAP8.
 The domain contains two blocks: gas (left) and ZrCoHx (right) with an interface between the two blocks.
-The diffusion is for this test case is given by [!citep](yu2024hydrogen) and the surface reaction rate $K$ is taken from [!citep](jat2013hydrogen) ($K_f=K_b=K$). Note that the diffusion used is based on ZrH$_{1.58}$ hydride since there is not diffusion value on ZrCo hydride. This should not affect the end results of the test case since simulation time goes until equlibrium is achieved.
+The diffusion is for this test case is given by [!citep](yu2024hydrogen) and the surface reaction rate $K$ is taken from [!citep](jat2013hydrogen) ($K_f=K_b=K$). Note that the diffusion used is based on ZrH$_{1.58}$ hydride since there is not diffusion value on ZrCo hydride. This should not affect the end results of the test case since simulation time goes until equilibrium is achieved.
 To model the interface, the input file employs the [InterfaceDiffusion.md] object to model the flux of hydrogen at the surface, and `ADMatInterfaceReactionZrCoHxPCT` to model the steady-state condition for the hydrogen concentration at the surface $C_s$ defined by:
 \begin{equation} \label{eq:test_interfacereaction}
 \frac{d C_s}{dt} = 0 = K (f_{at}(T,P) \rho - C_s),

--- a/doc/content/theory_manual.md
+++ b/doc/content/theory_manual.md
@@ -8,7 +8,7 @@ Tritium transport in solid materials can be divided into two main parts: (1) bul
 (2) surface reactions.
 We succinctly describe how TMAP8 models each part below. For more details on fuel cycle modeling, see [fuel_cycle_Abdou/index.md] or [fuel_cycle_Meschini/index.md].
 
-## Bulk Tramsport
+## Bulk Transport
 
 ### Main system of equations (the so-called strong forms)
 

--- a/doc/content/verification_and_validation/val-2f.md
+++ b/doc/content/verification_and_validation/val-2f.md
@@ -162,7 +162,7 @@ In this section provides the model parameters for this validation case. [val-2f_
 | $\Phi_D$  | Incident fluence                               | 1.5 $\times 10^{25}$        | atoms/m$^2$   | [!cite](dark2024modelling) |
 | $\phi_D$  | Incident flux                                  | 5.79 $\times 10^{19}$       | atoms/m$^2$/s | [!cite](dark2024modelling) |
 | $l_W$     | Length of the tungsten sample                  | 0.8                         | mm            | [!cite](dark2024modelling) |
-| $N$       | Tungten density                                | 6.3222 $\times 10^{28 }$    | at/m$^3$      | [J-Dark-PhD](https://zenodo.org/records/11085134) |
+| $N$       | Tungsten density                               | 6.3222 $\times 10^{28 }$    | at/m$^3$      | [J-Dark-PhD](https://zenodo.org/records/11085134) |
 
 
 !table id=val-2f_damaged_induced_traps caption=Damaged-induced traps parameters from [!cite](dark2024modelling) used in [eq:trapping_sites_density] to capture the evolution of trap properties with irradiation.

--- a/doc/content/verification_and_validation/ver-1g.md
+++ b/doc/content/verification_and_validation/ver-1g.md
@@ -46,7 +46,7 @@ For case (a), the initial pressures of A and B were 1 $\mu$Pa, and the reaction 
 C_{i_0} = 10^{-18} \frac{P_{i_0} N_a}{R T},
 \end{equation}
 
-where $P_{i_0}$ is the initial pressure, $N_a$ is Avogardro's constant, $R$ is the gas constant (from  [PhysicalConstants](source/utils/TMAP8PhysicalConstants.md)), and $T$ = 298.15 K (25$\deg$C) is the temperature. The factor $10^{-18}$ converts the concentration from atoms/m$^3$ to atoms/$\mu$m$^3$.
+where $P_{i_0}$ is the initial pressure, $N_a$ is Avogadro's constant, $R$ is the gas constant (from  [PhysicalConstants](source/utils/TMAP8PhysicalConstants.md)), and $T$ = 298.15 K (25$\deg$C) is the temperature. The factor $10^{-18}$ converts the concentration from atoms/m$^3$ to atoms/$\mu$m$^3$.
 
 ## Results and comparison against analytical solution
 

--- a/doc/workshops/tutorial/content/moose_intro.md
+++ b/doc/workshops/tutorial/content/moose_intro.md
@@ -299,7 +299,7 @@ _permeability(getADMaterialProperty<Real>("permeability"))
 // In the "computeQp..." method
 ADReal
 SomeObject::computeQpResidual() {
-return _permability[_qp] * _grad_u[_qp] * _grad_test[_qp];
+return _permeability[_qp] * _grad_u[_qp] * _grad_test[_qp];
 }
 ```
 
@@ -623,7 +623,7 @@ param = 5.0 * ${top_level_coef1} + ${top_level_coef2}  # Replacements
 +Krylov Solvers:+
 
 - GMRES (default)
-- Conjuate Gradient (CG), BiCGStab
+- Conjugate Gradient (CG), BiCGStab
 - Build Krylov subspace
 
 +Preconditioning:+

--- a/doc/workshops/tutorial/content/outro.md
+++ b/doc/workshops/tutorial/content/outro.md
@@ -4,7 +4,7 @@
 
 - Understand the purpose and capabilities of MOOSE and TMAP8.
 - Successfully have installed TMAP8.
-- Have run and modified simulations, as well as ploted and analyzed results.
+- Have run and modified simulations, as well as plotted and analyzed results.
 - Have identified and accessed documentation, tutorials, and community support.
 - Leave with a clear path for continued use and development.
 

--- a/doc/workshops/tutorial/content/tmap8_intro.md
+++ b/doc/workshops/tutorial/content/tmap8_intro.md
@@ -161,7 +161,7 @@ Later in the hands on part of this workshop, we will go through some V&V cases i
 !style halign=center
 TMAP8's example cases list simulations performed with TMAP8 that highlight specific capabilities.
 The example cases differ from the V&V cases in that they do not necessarily have analytical solutions or experimental data to be compared against.
-In geenral, the example cases also describe how the input file relates to the simulation, making them great resources for users. Hence, these cases can serve as additional tutorial cases, or as starting point for new simulations.
+In general, the example cases also describe how the input file relates to the simulation, making them great resources for users. Hence, these cases can serve as additional tutorial cases, or as starting point for new simulations.
 
 Check out the TMAP8 example cases and all relevant input file and documentation on the:
 


### PR DESCRIPTION
# Reason
Found typos in docs during training event.

# Design
Multiple typo fixes throughout the docs.

# Impact
Reduced understanding of docs and training materials.