### PR TITLE
Correcting steady state analytical solution in ver-1e

### DIFF
--- a/doc/content/verification_and_validation/ver-1e.md
+++ b/doc/content/verification_and_validation/ver-1e.md
@@ -8,18 +8,18 @@ This verification problem is taken from [!cite](longhurst1992verification, ambro
 
 ## Analytical solution at steady state
 
-The steady state solution for the PyC is given in [!cite](longhurst1992verification, ambrosek2008verification) as:
+The steady state solution for the PyC is calculated as:
 
 \begin{equation}
 \label{eqn:steady_state_pyc}
-    C = C_0 \left[1 + \frac{x}{l}  \left(\frac{a D_{PyC}}{a D_{PyC} + l D_{SiC}} - 1 \right) \right]
+    C = C_0 \left[\frac{(a-x) D_{SiC} + l D_{PyC}}{l D_{PyC} + a D_{SiC}} \right]
 \end{equation}
 
-while the concentration profile for the SiC layer is given as:
+while the concentration profile for the SiC layer is calculated as:
 
 \begin{equation}
 \label{eqn:steady_state_sic}
-    C = C_0 \left(\frac{a+l-x}{l} \right) \left(\frac{a D_{PyC}}{a D_{PyC} + l D_{SiC}} \right)
+    C = C_0 \left[\frac{(l+a-x) D_{PyC}}{l D_{PyC} + a D_{SiC}} \right]
 \end{equation}
 
 where

--- a/doc/content/verification_and_validation/ver-1e.md
+++ b/doc/content/verification_and_validation/ver-1e.md
@@ -36,8 +36,8 @@ where
 
     $D_{SiC}$ = diffusivity in SiC (2.622 $\times$ 10$^{-11}$ m$^2$/sec)
 
-!alert warning title=Typo in [!cite](ambrosek2008verification)
-The expressions of the analytical solution for the steady state case in TMAP4 ([!cite](longhurst1992verification)) and TMAP7 ([!cite](ambrosek2008verification)) are inconsistent with the results. To correct this, the limit of the transient solution, from [!cite](li2010analytical) as shown below, as $t = \infty$ is taken to calculate the concentration in the PyC and SiC layers.
+!alert warning title=Typo in [!cite](ambrosek2008verification) and [!cite](Simon2025)
+The expressions of the analytical solution for the steady state case in TMAP4 ([!cite](longhurst1992verification)) and TMAP7 ([!cite](ambrosek2008verification)) and provided in [!cite](Simon2025) are inconsistent with the results and with the transient solution. To correct this, the limit of the transient solution, from [!cite](li2010analytical) as shown below, is taken with $t = \infty$ to calculate the concentration in the PyC and SiC layers at steady-state.
 
 ## Analytical solution during transient
 

--- a/doc/content/verification_and_validation/ver-1e.md
+++ b/doc/content/verification_and_validation/ver-1e.md
@@ -8,14 +8,14 @@ This verification problem is taken from [!cite](longhurst1992verification, ambro
 
 ## Analytical solution at steady state
 
-The steady state solution for the PyC is calculated as:
+The steady state solution for the PyC is derived from the transient analytical solution with $t = \infty$ in [!cite](li2010analytical) as:
 
 \begin{equation}
 \label{eqn:steady_state_pyc}
     C = C_0 \left[\frac{(a-x) D_{SiC} + l D_{PyC}}{l D_{PyC} + a D_{SiC}} \right]
 \end{equation}
 
-while the concentration profile for the SiC layer is calculated as:
+while the concentration profile for the SiC layer is calculated similarly as:
 
 \begin{equation}
 \label{eqn:steady_state_sic}
@@ -35,6 +35,9 @@ where
     $D_{PyC}$ = diffusivity in PyC (1.274 $\times$ 10$^{-7}$ m$^2$/s)
 
     $D_{SiC}$ = diffusivity in SiC (2.622 $\times$ 10$^{-11}$ m$^2$/sec)
+
+!alert warning title=Typo in [!cite](ambrosek2008verification)
+The expressions of the analytical solution for the steady state case in TMAP4 ([!cite](longhurst1992verification)) and TMAP7 ([!cite](ambrosek2008verification)) are inconsistent with the results. To correct this, the limit of the transient solution, from [!cite](li2010analytical) as shown below, as $t = \infty$ is taken to calculate the concentration in the PyC and SiC layers.
 
 ## Analytical solution during transient
 

--- a/test/tests/ver-1e/comparison_ver-1e.py
+++ b/test/tests/ver-1e/comparison_ver-1e.py
@@ -320,8 +320,8 @@ D_PyC = 1.274e-7  # diffusivity in PyC (m^2/s)
 D_SiC = 2.622e-11  # diffusivity in SiC (m^2/s)
 
 x = tmap_distance_tmap7
-PyC_conc = c0 * (1 + (x / l) * ((a * D_PyC) / (a * D_PyC + l * D_SiC) - 1))
-SiC_conc = c0 * (((a + l - x) / l) * (a * D_PyC) / (a * D_PyC + l * D_SiC))
+PyC_conc = c0 * ((a - x) * D_SiC + l * D_PyC) / (l * D_PyC + a * D_SiC)
+SiC_conc = c0 * ((l + a - x) * D_PyC) / (l * D_PyC + a * D_SiC)
 analytical_conc_tmap7 = (x < a) * PyC_conc + (x >= a) * SiC_conc
 
 RMSE = np.sqrt(np.mean((tmap_conc_tmap7 - analytical_conc_tmap7) ** 2))

--- a/test/tests/ver-1e/comparison_ver-1e.py
+++ b/test/tests/ver-1e/comparison_ver-1e.py
@@ -304,8 +304,8 @@ D_PyC = 1.274e-7  # diffusivity in PyC (m^2/s)
 D_SiC = 2.622e-11  # diffusivity in SiC (m^2/s)
 
 x = tmap_distance_tmap4
-PyC_conc = c0 * (1 + (x / l) * ((a * D_PyC) / (a * D_PyC + l * D_SiC) - 1))
-SiC_conc = c0 * (((a + l - x) / l) * (a * D_PyC) / (a * D_PyC + l * D_SiC))
+PyC_conc = c0 * ((a - x) * D_SiC + l * D_PyC) / (l * D_PyC + a * D_SiC)
+SiC_conc = c0 * ((l + a - x) * D_PyC) / (l * D_PyC + a * D_SiC)
 analytical_conc_tmap4 = (x < a) * PyC_conc + (x >= a) * SiC_conc
 
 RMSE = np.sqrt(np.mean((tmap_conc_tmap4 - analytical_conc_tmap4) ** 2))


### PR DESCRIPTION
## Reason
The ver-1e steady state analytical solution does not correctly correspond to the transient analytical solution.

## Design
The steady state analytical solution was corrected to equal the limit of the transient analytical solution as t goes to infinity. Changes were made to the comparison file and the documentation.

## Impact
The steady state analytical solution now corresponds to the corrected tranisent analytical solution, improving calculation accuracy. This PR closes (Ref. #415).
