### PR TITLE
Add override flag. Closes #463. Depends on moose #33692

### DIFF
--- a/include/scalarkernels/FuelCycleSystemScalarKernel.h
+++ b/include/scalarkernels/FuelCycleSystemScalarKernel.h
@@ -27,7 +27,7 @@ public:
 
 protected:
   virtual GenericReal<is_ad> computeQpResidual() override;
-  virtual Real computeQpJacobian();
+  virtual Real computeQpJacobian() override;
   // Helper values for bookkeeping
   size_t _n_inputs;
   size_t _n_other_sources;


### PR DESCRIPTION
Closes #463. Depends on moose PR [#33692](https://github.com/idaholab/moose/pull/33692).

## Reason
Fixes clang build

## Design
Add override flag

## Impact
eliminates a warning
